### PR TITLE
Allow to use OAuth2 credentials using the standard Authorization header

### DIFF
--- a/ckanext/ngsiview/templates/package/snippets/resource_form.html
+++ b/ckanext/ngsiview/templates/package/snippets/resource_form.html
@@ -50,7 +50,7 @@
     <h3 class="ngsiview-input hidden">NGSI Extra</h3>
     {{ form.input('tenant', id='tenant', label=_('Tenant'), placeholder=_('Tenant'), value=data.tenant, error=errors.tenant, classes=['ngsiview-input', 'control-full', 'hidden']) }}
     {{ form.input('service_path', id='service-path', label=_('Service Path'), placeholder=_('Service Path'), value=data.service_path, error=errors.service_path, classes=['ngsiview-input', 'control-full', 'hidden']) }}
-    {{ form.select('oauth_req', label=_('OAuth-Token'), options=[{'value': 'true', 'text': _('required')},{'value': 'false', 'text': _('not required')}], selected=data.oauth_req, error=errors.oauth_req, classes=['ngsiview-input', 'hidden']) }}
+    {{ form.select('auth_type', label=_('Auth Type'), options=h.get_supported_auth(), selected=data.oauth_type, error=errors.auth_type, classes=['ngsiview-input', 'hidden']) }}
     {{ form.textarea('payload', id='field-payload', label=_('Payload'), placeholder=_('JSON query'), value=data.payload, error=errors.payload, classes=['ngsiview-v1', 'hidden'])}}
 
     <script type="text/javascript">

--- a/ckanext/ngsiview/tests/test_controller.py
+++ b/ckanext/ngsiview/tests/test_controller.py
@@ -60,8 +60,9 @@ class NgsiViewControllerTestCase(unittest.TestCase):
         return response, body
 
     @parameterized.expand([
-        ({'format': 'fiware-ngsi'}, {}),
-        ({"oauth_req": "true", 'format': 'fiware-ngsi'}, {"X-Auth-Token": "valid-access-token"}),
+        ({"format": "fiware-ngsi"}, {}),
+        ({"auth_type": "x-auth-token-fiware", 'format': 'fiware-ngsi'}, {"X-Auth-Token": "valid-access-token"}),
+        ({"auth_type": "oauth2", 'format': 'fiware-ngsi'}, {"Authorization": "Bearer valid-access-token"}),
         ({"tenant": "a", 'format': 'fiware-ngsi'}, {"FIWARE-Service": "a"}),
         ({"service_path": "/a", 'format': 'fiware-ngsi'}, {"FIWARE-ServicePath": "/a"}),
         ({"tenant": "a", "service_path": "/a,/b", 'format': 'fiware-ngsi'}, {"FIWARE-Service": "a", "FIWARE-ServicePath": "/a,/b"}),
@@ -192,7 +193,7 @@ class NgsiViewControllerTestCase(unittest.TestCase):
     def test_auth_required_request(self, auth_configured, base, logic, requests, toolkit, os):
         resource = {
             'url': "http://cb.example.org/v2/entites",
-            'oauth_req': 'true' if auth_configured else 'false',
+            'auth_type': 'oauth2' if auth_configured else 'none',
             'format': 'fiware-ngsi'
         }
         logic.get_action('resource_show').return_value = resource

--- a/ckanext/ngsiview/tests/test_plugin.py
+++ b/ckanext/ngsiview/tests/test_plugin.py
@@ -42,7 +42,7 @@ class NgsiViewPluginTest(unittest.TestCase):
     def test_can_view(self, resource_format, resource_url, same_domain, proxy_enabled, expected, datapreview, p):
         instance = plugin.NgsiView()
         datapreview.on_same_domain.return_value = same_domain
-        p.plugin_loaded.return_value = proxy_enabled
+        instance.proxy_is_enabled = proxy_enabled
         self.assertEqual(
             instance.can_view({'resource': {'format': resource_format, 'url': resource_url}}),
             expected


### PR DESCRIPTION
This PR allows to use the `Authorization` header instead of the `X-Auth-Token` from Open Stack. In addition, marks using OAuth 2 tokens through the `X-Auth-Token` header as deprecated.