### PR TITLE
Ignore env variables/config settings if they contain an empty string

### DIFF
--- a/ckanext/right_time_context/controller.py
+++ b/ckanext/right_time_context/controller.py
@@ -151,10 +151,10 @@ class ProxyNGSIController(base.BaseController):
 
         # Process verify configuration
         verify_conf = os.environ.get('CKAN_RIGHT_TIME_CONTEXT_VERIFY_REQUESTS', toolkit.config.get('ckan.right_time_context.verify_requests'))
-        if verify_conf is None:
+        if verify_conf is None or (isinstance(verify_conf, six.string_types) and verify_conf.strip() == ""):
             verify_conf = os.environ.get('CKAN_VERIFY_REQUESTS', toolkit.config.get('ckan.verify_requests'))
 
-        if isinstance(verify_conf, six.string_types):
+        if isinstance(verify_conf, six.string_types) and verify_conf.strip() != "":
             compare_env = verify_conf.lower().strip()
             if compare_env in ("true", "1", "on"):
                 verify = True

--- a/ckanext/right_time_context/tests/test_controller.py
+++ b/ckanext/right_time_context/tests/test_controller.py
@@ -239,7 +239,10 @@ class NgsiViewControllerTestCase(unittest.TestCase):
 
     @parameterized.expand([
         ({}, {}, True),
+        ({"CKAN_RIGHT_TIME_CONTEXT_VERIFY_REQUESTS": " "}, {}, True),
+        ({"CKAN_VERIFY_REQUESTS": " "}, {}, True),
         ({}, {"ckan.verify_requests": False}, False),
+        ({}, {"ckan.right_time_context.verify_requests": False}, False),
         ({}, {"ckan.right_time_context.verify_requests": False, "ckan.verify_requests": True}, False),
         ({"CKAN_VERIFY_REQUESTS": "false"}, {"ckan.verify_requests": True}, False),
         ({"CKAN_RIGHT_TIME_CONTEXT_VERIFY_REQUESTS": "True"}, {"ckan.verify_requests": False}, True),
@@ -250,6 +253,7 @@ class NgsiViewControllerTestCase(unittest.TestCase):
         ({"CKAN_RIGHT_TIME_CONTEXT_VERIFY_REQUESTS": "off"}, {"ckan.verify_requests": True}, False),
         ({"CKAN_RIGHT_TIME_CONTEXT_VERIFY_REQUESTS": "0"}, {"ckan.verify_requests": True}, False),
         ({"CKAN_RIGHT_TIME_CONTEXT_VERIFY_REQUESTS": "/path"}, {"ckan.verify_requests": True}, "/path"),
+        ({"CKAN_RIGHT_TIME_CONTEXT_VERIFY_REQUESTS": " "}, {"ckan.verify_requests": False}, False),
         ({"CKAN_VERIFY_REQUESTS": "/path/A/b"}, {"ckan.verify_requests": "path/2"}, "/path/A/b"),
     ])
     @patch.multiple("ckanext.right_time_context.controller", base=DEFAULT, logic=DEFAULT, requests=DEFAULT, toolkit=DEFAULT, os=DEFAULT)


### PR DESCRIPTION
This PR makes this plugin ignore env variables/config settings if they contain an empty string.