### PR TITLE
ckanext- right-time-context cannot communicate with orion in same-domain 

### DIFF
--- a/ckanext/right_time_context/controller.py
+++ b/ckanext/right_time_context/controller.py
@@ -42,7 +42,7 @@ class ProxyNGSIController(base.BaseController):
 
     def _proxy_query_resource(self, resource, parsed_url, headers, verify=True):
 
-        if parsed_url.path.find('/v1/queryContext') != -1:
+        if parsed_url.path.lower().find('/v1/querycontext') != -1:
             if resource.get("payload", "").strip() == "":
                 details = 'Please add a payload to complete the query.'
                 base.abort(409, detail=details)

--- a/ckanext/right_time_context/plugin.py
+++ b/ckanext/right_time_context/plugin.py
@@ -39,7 +39,7 @@ NGSI_REG_FORMAT = 'fiware-ngsi-registry'
 
 
 def check_query(resource):
-    parsedurl = resource['url']
+    parsedurl = resource['url'].lower()
     return parsedurl.find('/v2/entities') != -1 or parsedurl.find('/v1/querycontext') != -1 or parsedurl.find('/v1/contextentities/') != -1
 
 
@@ -140,8 +140,7 @@ class NgsiView(p.SingletonPlugin):
             view_enable = [False, details]
             url = ''
         else:
-            if not same_domain:
-                url = self.get_proxified_ngsi_url(data_dict)
+            url = self.get_proxified_ngsi_url(data_dict)
 
             if resource['auth_type'] != 'none' and not p.toolkit.c.user:
                 details = "</br></br>In order to see this resource properly, you need to be logged in.</br></br></br>"

--- a/ckanext/right_time_context/templates/package/snippets/resource_form.html
+++ b/ckanext/right_time_context/templates/package/snippets/resource_form.html
@@ -142,7 +142,7 @@
                 }
             }
 
-            if (url.pathname.indexOf('/v1/queryContext') !== -1) {
+            if (url.pathname.toLowerCase().indexOf('/v1/querycontext') !== -1) {
                 $('.ngsiview-v1').removeClass('hidden');
             } else {
                 $('.ngsiview-v1').addClass('hidden');


### PR DESCRIPTION
When the orion query API was entered in the following form as shown below on CKAN, the result was not displayed for it.

    /v1/queryContext
    /v1/contextEntities

In orion,ngsi can handle both uppercase and lowercase letters(queryContext, contextEntities), but NGSI view can handle in lowercase letters only.
And,NGSI view compares API names in all lowercase letters(querycontext, contextentities).

Secondly,in plugin.py `"setup_template_variables"` method `self.get_proxified_ngsi_url(data_dict)` is called only in the case of different-domain and does not works properly in case of same-domain. Thus, I have provided a fix for it.