### PR TITLE
Remove same domain checks

### DIFF
--- a/ckanext/right_time_context/plugin.py
+++ b/ckanext/right_time_context/plugin.py
@@ -28,11 +28,6 @@ import ckan.lib.helpers as h
 
 log = logging.getLogger(__name__)
 
-try:
-    import ckan.lib.datapreview as datapreview
-except ImportError:
-    pass
-
 
 NGSI_FORMAT = 'fiware-ngsi'
 NGSI_REG_FORMAT = 'fiware-ngsi-registry'
@@ -114,16 +109,14 @@ class NgsiView(p.SingletonPlugin):
     def can_view(self, data_dict):
         resource = data_dict['resource']
         format_lower = resource.get('format', '').lower()
-        same_domain = datapreview.on_same_domain(data_dict)
 
         if (format_lower == NGSI_FORMAT and check_query(resource)) or format_lower == NGSI_REG_FORMAT:
-            return same_domain or self.proxy_is_enabled
+            return self.proxy_is_enabled
         else:
             return False
 
     def setup_template_variables(self, context, data_dict):
         resource = data_dict['resource']
-        same_domain = datapreview.on_same_domain(data_dict)
         format_lower = resource.get('format', '').lower()
         resource.setdefault('auth_type', 'none')
 
@@ -133,7 +126,7 @@ class NgsiView(p.SingletonPlugin):
             f_details = "This is not a ContextBroker query, please check Orion Context Broker documentation."
             h.flash_error(f_details, allow_html=False)
             view_enable = [False, details]
-        elif not same_domain and not self.proxy_is_enabled:
+        elif not self.proxy_is_enabled:
             details = "</br></br>Enable resource_proxy</br></br></br>"
             f_details = "Enable resource_proxy."
             h.flash_error(f_details, allow_html=False)

--- a/ckanext/right_time_context/plugin.py
+++ b/ckanext/right_time_context/plugin.py
@@ -121,35 +121,32 @@ class NgsiView(p.SingletonPlugin):
         resource.setdefault('auth_type', 'none')
 
         url = resource['url']
-        if format_lower == NGSI_FORMAT and not check_query(resource):
-            details = "</br></br>This is not a ContextBroker query, please check <a href='https://forge.fiware.org/plugins/mediawiki/wiki/fiware/index.php/Publish/Subscribe_Broker_-_Orion_Context_Broker_-_User_and_Programmers_Guide'>Orion Context Broker documentation</a></br></br></br>"
-            f_details = "This is not a ContextBroker query, please check Orion Context Broker documentation."
-            h.flash_error(f_details, allow_html=False)
-            view_enable = [False, details]
-        elif not self.proxy_is_enabled:
+        if not self.proxy_is_enabled:
             details = "</br></br>Enable resource_proxy</br></br></br>"
             f_details = "Enable resource_proxy."
             h.flash_error(f_details, allow_html=False)
             view_enable = [False, details]
-            url = ''
+        elif resource['auth_type'] != 'none' and not self.oauth2_is_enabled:
+            details = "</br></br>In order to see this resource properly, enable oauth2 extension</br></br></br>"
+            f_details = "In order to see this resource properly, enable oauth2 extension."
+            h.flash_error(f_details, allow_html=False)
+            view_enable = [False, details]
+        elif format_lower == NGSI_FORMAT and not check_query(resource):
+            details = "</br></br>This is not a ContextBroker query, please check <a href='https://forge.fiware.org/plugins/mediawiki/wiki/fiware/index.php/Publish/Subscribe_Broker_-_Orion_Context_Broker_-_User_and_Programmers_Guide'>Orion Context Broker documentation</a></br></br></br>"
+            f_details = "This is not a ContextBroker query, please check Orion Context Broker documentation."
+            h.flash_error(f_details, allow_html=False)
+            view_enable = [False, details]
+        elif resource['auth_type'] != 'none' and not p.toolkit.c.user:
+            details = "</br></br>In order to see this resource properly, you need to be logged in.</br></br></br>"
+            f_details = "In order to see this resource properly, you need to be logged in."
+            h.flash_error(f_details, allow_html=False)
+            view_enable = [False, details]
         else:
+            # All checks passed
             url = self.get_proxified_ngsi_url(data_dict)
 
-            if resource['auth_type'] != 'none' and not p.toolkit.c.user:
-                details = "</br></br>In order to see this resource properly, you need to be logged in.</br></br></br>"
-                f_details = "In order to see this resource properly, you need to be logged in."
-                h.flash_error(f_details, allow_html=False)
-                view_enable = [False, details]
-
-            elif resource['auth_type'] != 'none' and not self.oauth2_is_enabled:
-                details = "</br></br>In order to see this resource properly, enable oauth2 extension</br></br></br>"
-                f_details = "In order to see this resource properly, enable oauth2 extension."
-                h.flash_error(f_details, allow_html=False)
-                view_enable = [False, details]
-
-            else:
-                data_dict['resource']['url'] = url
-                view_enable = [True, 'OK']
+            data_dict['resource']['url'] = url
+            view_enable = [True, 'OK']
 
         return {
             'resource_json': json.dumps(data_dict['resource']),

--- a/ckanext/right_time_context/tests/test_plugin.py
+++ b/ckanext/right_time_context/tests/test_plugin.py
@@ -30,19 +30,17 @@ import ckanext.right_time_context.plugin as plugin
 class NgsiViewPluginTest(unittest.TestCase):
 
     @parameterized.expand([
-        ('CSV', '', False, False, False),
-        ('CSV', '', False, True, False),
-        ('CSV', '', True, False, False),
-        ('fiware-ngsi', 'https://cb.example.com/v2/entities', True, False, True),
-        ('FIWARE-ngsi', 'https://cb.example.com/v2/entities', True, False, True),
-        ('fiware-ngsi', 'https://cb.example.com/v2/entities', False, False, False),
-        ('FIWARE-ngsi', 'https://cb.example.com/v2/entities', False, True, True),
-        ('FIWARE-ngsi', 'https://cb.example.com/othe/path', True, False, False),
+        ('CSV', '', False, False),
+        ('CSV', '', True, False),
+        ('fiware-ngsi', 'https://cb.example.com/v2/entities', False, False),
+        ('FIWARE-ngsi', 'https://cb.example.com/v2/entities', False, False),
+        ('FIWARE-ngsi', 'https://cb.example.com/v2/entities', True, True),
+        ('FIWARE-ngsi', 'https://cb.example.com/other/path', False, False),
+        ('fiware-ngsi', 'https://cb.example.com/other/path', True, False),
     ])
-    @patch.multiple('ckanext.right_time_context.plugin', datapreview=DEFAULT, p=DEFAULT)
-    def test_can_view(self, resource_format, resource_url, same_domain, proxy_enabled, expected, datapreview, p):
+    @patch.multiple('ckanext.right_time_context.plugin', p=DEFAULT)
+    def test_can_view(self, resource_format, resource_url, proxy_enabled, expected, p):
         instance = plugin.NgsiView()
-        datapreview.on_same_domain.return_value = same_domain
         instance.proxy_is_enabled = proxy_enabled
         self.assertEqual(
             instance.can_view({'resource': {'format': resource_format, 'url': resource_url}}),


### PR DESCRIPTION
This WIP PR removes same domain checks as now the plugin requires the `resource_proxy` extension also when connecting to the same domain as the CKAN instance. See #8 for more details.

I'm working also to add new tests cases to stress the paths involved in this change.